### PR TITLE
Minor changes to `class StandardScaleNormalizer`

### DIFF
--- a/maldi_learn/preprocessing/normalization.py
+++ b/maldi_learn/preprocessing/normalization.py
@@ -119,7 +119,7 @@ class StandardScaleNormalizer(BaseEstimator, TransformerMixin):
         self.mean = np.mean(np.array(l), axis=0)
         self.std = np.std(np.array(l), axis=0)
         # Set standard deviation to None for bins with zero variance
-        self.std[self.std == 0] = None
+        self.std[self.std == 0] = np.nan
         return self
 
     def transform(self, X):

--- a/maldi_learn/preprocessing/normalization.py
+++ b/maldi_learn/preprocessing/normalization.py
@@ -106,7 +106,7 @@ class StandardScaleNormalizer(BaseEstimator, TransformerMixin):
     """
     def _normalize_spectrum(self, spectrum):
         spectrum_scaled = spectrum.copy()
-        if self.std is not None:
+        if self.std is not np.nan:
             # Avoid division by zero error when standard deviation is zero
             spectrum_scaled[:, 1] = (spectrum.intensities - self.mean) / self.std
         else:


### PR DESCRIPTION
1. Check if the standard deviation is None (indicating a zero variance bin), and if so, we set all the intensities to zero. 
2. Set the standard deviation to None for bins with zero variance in the fit method to simplify the normalization in the transform method.