### PR TITLE
Speed up `BinningVectorizer`

### DIFF
--- a/maldi_learn/vectorization/binning.py
+++ b/maldi_learn/vectorization/binning.py
@@ -72,19 +72,10 @@ class BinningVectorizer(BaseEstimator, TransformerMixin):
 
     def _transform(self, spectrum):
         times = spectrum[:, 0]
-        indices = np.digitize(times, self.bin_edges_, right=True)
 
-        # Drops all instances which are outside the defined bin
-        # range.
-        valid = (indices >= 1) & (indices <= self.n_bins)
+        valid = (times > self.bin_edges_[0]) & (times <= self.bin_edges_[-1])
         spectrum = spectrum[valid]
 
-        # Need to update indices to ensure that the first bin is at
-        # position zero.
-        indices = indices[valid] - 1
-        identity = np.eye(self.n_bins)
-
-        vec = np.sum(
-            identity[indices] * spectrum[:, 1][:, np.newaxis], axis=0)
+        vec = np.histogram(spectrum[:, 0], bins=self.bin_edges_, weights=spectrum[:, 1])[0]
 
         return vec

--- a/maldi_learn/vectorization/binning.py
+++ b/maldi_learn/vectorization/binning.py
@@ -41,13 +41,14 @@ class BinningVectorizer(BaseEstimator, TransformerMixin):
 
     def fit(self, X, y=None):
         """Fit transformer, derives bins used to bin spectra."""
-        combined_times = np.concatenate(
-            [spectrum[:, 0] for spectrum in X], axis=0)
-        min_range = min(self.min_bin, np.min(combined_times))
-        max_range = max(self.max_bin, np.max(combined_times))
-
-        _, self.bin_edges_ = np.histogram(
-            combined_times, self.n_bins, range=(min_range, max_range))
+        # Find the smallest and largest time values in the dataset
+        # It should be that the first/last time value is the smallest/biggest
+        # but we call min/max to be safe.
+        min_range = min(spectrum[:, 0].min() for spectrum in X)
+        min_range = min(min_range, self.min_bin)
+        max_range = max(spectrum[:, 0].max() for spectrum in X)
+        max_range = max(max_range, self.max_bin)
+        self.bin_edges_ = np.linspace(min_range, max_range, self.n_bins + 1)
         return self
 
     def transform(self, X):


### PR DESCRIPTION
First, thanks for the great library!

I was playing with methods for the DRIAMS-A part of the data and noticed that `BinningVectorizer` was using a lot of time. Specifically, I load all years, species and Ciprofloxacin + Penicillin:
```python
explorer = DRIAMSDatasetExplorer(DRIAMS_ROOT)

driams_dataset = load_driams_dataset(
            explorer.root,
            'DRIAMS-A',
            ['2015', '2016', '2017', '2018'],
            '*',
            ['Ciprofloxacin', 'Penicillin'],
            handle_missing_resistance_measurements='remove_if_all_missing',
            id_suffix='strat',
)
len(driams_dataset.X)  # 33415
```

Using the `BinningVectorizer` with 200 bins then takes 9 seconds for fitting and over 6 minutes for the transform:
```python
bv = BinningVectorizer(200, min_bin=2000, max_bin=20000)
bv.fit(driams_dataset.X)               # 8.9s
Xold = bv.transform(driams_dataset.X)  # 6m 10.0s
```
The time also seems to worsen as I increase the bin count.

I tried to optimize the code for `fit` and `transform` and I can now get results significantly faster:
```python
nbv = NewBinningVectorizer(200, min_bin=2000, max_bin=20000)
nbv.fit(driams_dataset.X)               # 2.1s
Xnew = nbv.transform(driams_dataset.X)  # 20.8s
```
The results are also the same (up to small rounding errors):
```python
np.all(mbv.bin_edges_ == bv.bin_edges_)         # True
np.abs(Xnew - Xold).max()                       # abs. error = 4.104762319975808e-15
np.abs(Xnew - Xold).max() / np.abs(Xold).max()  # rel. error = 1.3664372704227028e-14
```
It also passes the test in `tests/vectorization/test_binning_vectorizer.py`.

I haven't thoroughly checked the performance for smaller datasets. However, with the smaller example in the README (1520 samples) the new code is still faster.

Hopefully, this is useful :) If anything looks weird or should be changed please let me know! I tried to explain each change in their respective commits.